### PR TITLE
chore: Faster implementation of ranged array

### DIFF
--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -6,7 +6,7 @@ export const fetchPets = async (contract: Wagmipet, userAddress: string): Promis
 
 	return Object.fromEntries(
 		await Promise.all(
-			new Array(userBalance.toNumber()).fill(undefined).map(async (_, index) => {
+			[...Array(userBalance.toNumber())].map(async (_, index) => {
 				const tokenIndex: BigNumber = await contract.tokenOfOwnerByIndex(userAddress, index)
 
 				return [tokenIndex.toNumber(), await contract.getName(tokenIndex)]


### PR DESCRIPTION
Noticed you use `new Array($range).fill(undefined)` for mimicking [range-like](https://ramdajs.com/docs/#range) function. I've [used this](https://github.com/hoprnet/hopr-community/blob/main/hopr-stake/packages/frontend/components/NFTQuery.tsx#L231) in the past, so was curious on which approach was faster, so I [benchmarked it](https://jsbench.me/evkth9p3aj/1) and seems like it's actually faster to spread it than filling it (no pun intended). Funny enough, I also do cast `BigNumber`s with `+$val` instead of `$val.toNumber()` and seems like `toNumber` is [faster](https://jsbench.me/xmkthaajdt/1), TIL!

This PR uses `[...Array($val)]` instead of your `new Array($val).fill(undefined)`